### PR TITLE
Fix things up to work with modern libxdo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'ffi', '>= 1.0.0'
+gemspec
 
-group :development do
-  gem 'rdoc', '>= 3.12'
-  gem 'rspec', '>= 2.8.0'
-  gem 'bundler', '>= 1.0.0'
-  gem 'jeweler', '>= 1.6.4'
-  gem 'rcov', '>= 0'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -85,6 +87,7 @@ DEPENDENCIES
   jeweler (>= 1.6.4)
   rdoc (>= 3.12)
   rspec (>= 2.8.0)
+  rspec-collection_matchers
   simplecov
   simplecov-rcov
   x_do!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,93 @@
+PATH
+  remote: .
+  specs:
+    x_do (0.1.2)
+      ffi (>= 1.0.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    ffi (1.0.11)
-    git (1.2.5)
-    jeweler (1.6.4)
-      bundler (~> 1.0)
+    addressable (2.4.0)
+    builder (3.2.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.10)
+    git (1.3.0)
+    github_api (0.13.1)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      multi_json (>= 1.7.5, < 2.0)
+      oauth2
+    hashie (3.4.3)
+    highline (1.7.8)
+    jeweler (2.1.1)
+      builder
+      bundler (>= 1.0)
       git (>= 1.2.5)
+      github_api
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
       rake
-    json (1.6.4)
-    rake (0.9.2.2)
-    rcov (0.9.11)
-    rdoc (3.12)
+      rdoc
+      semver
+    json (1.8.3)
+    jwt (1.5.1)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    oauth2 (1.1.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0, < 1.5.2)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    rack (1.6.4)
+    rake (11.1.2)
+    rdoc (4.2.2)
       json (~> 1.4)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    semver (1.0.1)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
+    thread_safe (0.3.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (>= 1.0.0)
-  ffi (>= 1.0.0)
   jeweler (>= 1.6.4)
-  rcov
   rdoc (>= 3.12)
   rspec (>= 2.8.0)
+  simplecov
+  simplecov-rcov
+  x_do!
+
+BUNDLED WITH
+   1.11.2

--- a/lib/x_do/ffi_functions.rb
+++ b/lib/x_do/ffi_functions.rb
@@ -5,61 +5,90 @@ class XDo
 
 # :nodoc: function attachments
 module FFILib
+  def self.alias_class_method(target, source)
+    singleton_class.send(:alias_method, target, source)
+  end
+
   attach_function :xdo_new, [:string], :pointer
   attach_function :xdo_version, [], :string
   attach_function :xdo_free, [:pointer], :void
-  attach_function :xdo_window_get_active, [:pointer, :pointer],
+  attach_function :xdo_get_active_window, [:pointer, :pointer],
                                           XDo::FFILib::Status
-  attach_function :xdo_window_get_focus, [:pointer, :pointer],
+  attach_function :xdo_get_focused_window, [:pointer, :pointer],
                                          XDo::FFILib::Status
-  attach_function :xdo_window_sane_get_focus, [:pointer, :pointer],
+  attach_function :xdo_get_focused_window_sane, [:pointer, :pointer],
                                               XDo::FFILib::Status
 
-  attach_function :xdo_window_get_pid, [:pointer, :window], :int
+  attach_function :xdo_get_pid_window, [:pointer, :window], :int
 
-  attach_function :xdo_window_search, [:pointer, :pointer, :pointer, :pointer],
+  attach_function :xdo_search_windows, [:pointer, :pointer, :pointer, :pointer],
                                       XDo::FFILib::Status
 
-  attach_function :xdo_window_activate, [:pointer, :window], XDo::FFILib::Status
-  attach_function :xdo_window_focus, [:pointer, :window], XDo::FFILib::Status
-  attach_function :xdo_window_raise, [:pointer, :window], XDo::FFILib::Status
-                                     
-  attach_function :xdo_get_window_name, [:pointer, :window, :pointer, :pointer, 
+  attach_function :xdo_activate_window, [:pointer, :window], XDo::FFILib::Status
+  attach_function :xdo_focus_window, [:pointer, :window], XDo::FFILib::Status
+  attach_function :xdo_raise_window, [:pointer, :window], XDo::FFILib::Status
+
+  attach_function :xdo_get_window_name, [:pointer, :window, :pointer, :pointer,
                                          :pointer], XDo::FFILib::Status
   attach_function :xdo_get_window_location, [:pointer, :window, :pointer,
                                              :pointer, :pointer],
                                             XDo::FFILib::Status
   attach_function :xdo_get_window_size, [:pointer, :window, :pointer, :pointer],
                                         XDo::FFILib::Status
-  attach_function :xdo_window_move, [:pointer, :window, :int, :int],
+  attach_function :xdo_move_window, [:pointer, :window, :int, :int],
                                     XDo::FFILib::Status
-  attach_function :xdo_window_setsize, [:pointer, :window, :int, :int, :int],
+  attach_function :xdo_set_window_size, [:pointer, :window, :int, :int, :int],
                                        XDo::FFILib::Status
-  attach_function :xdo_mouselocation, [:pointer, :pointer, :pointer, :pointer],
+  attach_function :xdo_get_mouse_location, [:pointer, :pointer, :pointer, :pointer],
                                       XDo::FFILib::Status
-  attach_function :xdo_mousemove, [:pointer, :int, :int, :int],
+  attach_function :xdo_move_mouse, [:pointer, :int, :int, :int],
                                   XDo::FFILib::Status
-  attach_function :xdo_mousemove_relative, [:pointer, :int, :int],
+  attach_function :xdo_move_mouse_relative, [:pointer, :int, :int],
                                            XDo::FFILib::Status
-  attach_function :xdo_mouse_wait_for_move_from, [:pointer, :int, :int],
+  attach_function :xdo_wait_for_mouse_move_from, [:pointer, :int, :int],
                                                  XDo::FFILib::Status
-  attach_function :xdo_mouse_wait_for_move_to, [:pointer, :int, :int],
+  attach_function :xdo_wait_for_mouse_move_to, [:pointer, :int, :int],
                                                XDo::FFILib::Status
-  
-  attach_function :xdo_mousemove_relative_to_window, [:pointer, :window, :int,
-                                                      :int], XDo::FFILib::Status
-  attach_function :xdo_mousedown, [:pointer, :window, :int], XDo::FFILib::Status
-  attach_function :xdo_mouseup, [:pointer, :window, :int], XDo::FFILib::Status
-  attach_function :xdo_click, [:pointer, :window, :int], XDo::FFILib::Status
 
-  attach_function :xdo_type, [:pointer, :window, :string, :int],
+  attach_function :xdo_move_mouse_relative_to_window, [:pointer, :window, :int,
+                                                      :int], XDo::FFILib::Status
+  attach_function :xdo_mouse_down, [:pointer, :window, :int], XDo::FFILib::Status
+  attach_function :xdo_mouse_up, [:pointer, :window, :int], XDo::FFILib::Status
+  attach_function :xdo_click_window, [:pointer, :window, :int], XDo::FFILib::Status
+
+  attach_function :xdo_enter_text_window, [:pointer, :window, :string, :int],
                              XDo::FFILib::Status
-  attach_function :xdo_keysequence, [:pointer, :window, :string, :int],
+  attach_function :xdo_send_keysequence_window, [:pointer, :window, :string, :int],
                                     XDo::FFILib::Status
-  attach_function :xdo_keysequence_down, [:pointer, :window, :string, :int],
+  attach_function :xdo_send_keysequence_window_down, [:pointer, :window, :string, :int],
                                          XDo::FFILib::Status
-  attach_function :xdo_keysequence_up, [:pointer, :window, :string, :int],
+  attach_function :xdo_send_keysequence_window_up, [:pointer, :window, :string, :int],
                                        XDo::FFILib::Status
+
+  alias_class_method :xdo_window_get_active, :xdo_get_active_window
+  alias_class_method :xdo_window_get_focus, :xdo_get_focused_window
+  alias_class_method :xdo_window_sane_get_focus, :xdo_get_focused_window_sane
+  alias_class_method :xdo_window_search, :xdo_search_windows
+  alias_class_method :xdo_mouselocation, :xdo_get_mouse_location
+  alias_class_method :xdo_mouse_wait_for_move_to, :xdo_wait_for_mouse_move_to
+  alias_class_method :xdo_mouse_wait_for_move_from, :xdo_wait_for_mouse_move_from
+  alias_class_method :xdo_mousemove, :xdo_move_mouse
+  alias_class_method :xdo_window_get_pid, :xdo_get_pid_window
+  alias_class_method :xdo_window_active, :xdo_activate_window
+  alias_class_method :xdo_window_focus, :xdo_focus_window
+  alias_class_method :xdo_window_raise, :xdo_raise_window
+  alias_class_method :xdo_window_move, :xdo_move_window
+  alias_class_method :xdo_window_setsize, :xdo_set_window_size
+  alias_class_method :xdo_mousemove_relative, :xdo_move_mouse_relative
+  alias_class_method :xdo_mousemove_relative_to_window, :xdo_move_mouse_relative_to_window
+  alias_class_method :xdo_mousedown, :xdo_mouse_down
+  alias_class_method :xdo_mouseup, :xdo_mouse_up
+  alias_class_method :xdo_click, :xdo_click_window
+  alias_class_method :xdo_type, :xdo_enter_text_window
+  alias_class_method :xdo_keysequence, :xdo_send_keysequence_window
+  alias_class_method :xdo_keysequence_down, :xdo_send_keysequence_window_down
+  alias_class_method :xdo_keysequence_up, :xdo_send_keysequence_window_up
+
 end  # module XDo::FFILib
 
 end  # namespace XDo

--- a/lib/x_do/ffi_lib.rb
+++ b/lib/x_do/ffi_lib.rb
@@ -12,15 +12,13 @@ module FFILib
   rescue FFI::NotFoundError
     ffi_lib 'libxdo.so'
   end
-  
+
   # :nodoc: lifted from xdo.h
   class XDoContext < FFI::Struct
     layout :xdpy, :pointer,
            :display_name, :string,
            :charcodes, :pointer,
            :charcodes_len, :int,
-           :modmap, :pointer,
-           :keymap, :pointer,
            :keycode_high, :int,
            :keycode_low, :int,
            :keysyms_per_keycode, :int,
@@ -29,7 +27,7 @@ module FFILib
            :debug, :int,
            :features_mask, :int
   end  # class XDo::FFILib::XDoContext
-  
+
   # :nodoc: lifted from xdo.h
   class XDoSearch < FFI::Struct
     layout :title, :pointer,
@@ -45,7 +43,7 @@ module FFILib
            :desktop, :long,
            :limit, :uint
   end  # class XDo::FFILib::XDoSearch
-  
+
   # :nodoc: Window from X11/X.h (Window -> XID -> unsigned long)
   typedef :ulong, :window
   # :nodoc: useconds_t from sys/types.h

--- a/lib/x_do/ffi_lib.rb
+++ b/lib/x_do/ffi_lib.rb
@@ -6,7 +6,12 @@ class XDo
 # FFI to the raw libxdo functions.
 module FFILib
   extend FFI::Library
-  ffi_lib 'libxdo.so'
+
+  begin
+    ffi_lib 'libxdo.so.3'
+  rescue FFI::NotFoundError
+    ffi_lib 'libxdo.so'
+  end
   
   # :nodoc: lifted from xdo.h
   class XDoContext < FFI::Struct

--- a/lib/x_do/ffi_lib.rb
+++ b/lib/x_do/ffi_lib.rb
@@ -9,7 +9,7 @@ module FFILib
 
   begin
     ffi_lib 'libxdo.so.3'
-  rescue FFI::NotFoundError
+  rescue FFI::NotFoundError, LoadError
     ffi_lib 'libxdo.so'
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
+require 'rspec/collection_matchers'
 require 'x_do'
 
 # Requires supporting files with custom matchers and macros, etc,
@@ -8,5 +9,5 @@ require 'x_do'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  
+
 end

--- a/x_do.gemspec
+++ b/x_do.gemspec
@@ -50,12 +50,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.15"
   s.summary = "Ruby FFI for libxdo (X mouse / keypress injector)"
-  s.add_runtime_dependency(%q<ffi>, [">= 1.0.0"])
-  s.add_development_dependency(%q<rdoc>, [">= 3.12"])
-  s.add_development_dependency(%q<rspec>, [">= 2.8.0"])
-  s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
-  s.add_development_dependency(%q<jeweler>, [">= 1.6.4"])
-  s.add_development_dependency(%q<simplecov>, [">= 0"])
-  s.add_development_dependency(%q<simplecov-rcov>, [">= 0"])
+  s.add_runtime_dependency('ffi', [">= 1.0.0"])
+  s.add_development_dependency('rdoc', [">= 3.12"])
+  s.add_development_dependency('rspec', [">= 2.8.0"])
+  s.add_development_dependency('rspec-collection_matchers', ['>= 0'])
+  s.add_development_dependency('bundler', [">= 1.0.0"])
+  s.add_development_dependency('jeweler', [">= 1.6.4"])
+  s.add_development_dependency('simplecov', [">= 0"])
+  s.add_development_dependency('simplecov-rcov', [">= 0"])
 end
 

--- a/x_do.gemspec
+++ b/x_do.gemspec
@@ -50,47 +50,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.15"
   s.summary = "Ruby FFI for libxdo (X mouse / keypress injector)"
-
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<ffi>, [">= 1.0.0"])
-      s.add_development_dependency(%q<rdoc>, [">= 3.12"])
-      s.add_development_dependency(%q<rspec>, [">= 2.8.0"])
-      s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_development_dependency(%q<jeweler>, [">= 1.6.4"])
-      s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<ffi>, [">= 1.0.0"])
-      s.add_development_dependency(%q<rspec>, ["~> 2.5.0"])
-      s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
-      s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
-      s.add_development_dependency(%q<rcov>, [">= 0"])
-    else
-      s.add_dependency(%q<ffi>, [">= 1.0.0"])
-      s.add_dependency(%q<rdoc>, [">= 3.12"])
-      s.add_dependency(%q<rspec>, [">= 2.8.0"])
-      s.add_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_dependency(%q<jeweler>, [">= 1.6.4"])
-      s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<ffi>, [">= 1.0.0"])
-      s.add_dependency(%q<rspec>, ["~> 2.5.0"])
-      s.add_dependency(%q<bundler>, ["~> 1.0.0"])
-      s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
-      s.add_dependency(%q<rcov>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<ffi>, [">= 1.0.0"])
-    s.add_dependency(%q<rdoc>, [">= 3.12"])
-    s.add_dependency(%q<rspec>, [">= 2.8.0"])
-    s.add_dependency(%q<bundler>, [">= 1.0.0"])
-    s.add_dependency(%q<jeweler>, [">= 1.6.4"])
-    s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<ffi>, [">= 1.0.0"])
-    s.add_dependency(%q<rspec>, ["~> 2.5.0"])
-    s.add_dependency(%q<bundler>, ["~> 1.0.0"])
-    s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
-    s.add_dependency(%q<rcov>, [">= 0"])
-  end
+  s.add_runtime_dependency(%q<ffi>, [">= 1.0.0"])
+  s.add_development_dependency(%q<rdoc>, [">= 3.12"])
+  s.add_development_dependency(%q<rspec>, [">= 2.8.0"])
+  s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
+  s.add_development_dependency(%q<jeweler>, [">= 1.6.4"])
+  s.add_development_dependency(%q<simplecov>, [">= 0"])
+  s.add_development_dependency(%q<simplecov-rcov>, [">= 0"])
 end
 


### PR DESCRIPTION
Mainly adjusting method names, but problems with other gems and lots of associated fun stuff as well.

At some point I'd like to properly replace the old names, but that's a project for another day.

Still seeing two spec failures, both reporting that Xdo#display_name is `nil` even when an explicit display was given, but it looks like it's still using the display passed to `Xdo.new`, so a minor issue afaic.
